### PR TITLE
OSOE-647: Under Orchard Core 1.6, menu items generated via MainMenuNavigationProvider are prefixed with /Admin in Lombiq.BaseTheme

### DIFF
--- a/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -56,7 +56,7 @@ public static class TestCaseUITestContextExtensions
         context.Get(By.CssSelector(".menuWidget__content .nav-link[href='/about']")).Text.Trim().ShouldBe("About");
     }
 
-    public static async Task TestAddingMenuItemToBlogMainMenu(this UITestContext context)
+    public static async Task TestAddingMenuItemToBlogMainMenuAsync(this UITestContext context)
     {
         await context.GoToAdminRelativeUrlAsync("/Contents/ContentItems/Menu");
         await context.ClickReliablyOnAsync(By.ClassName("edit"));

--- a/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -43,4 +43,11 @@ public static class TestCaseUITestContextExtensions
         await context.ClickMainMenuPathAsync("Log In");
         context.Exists(By.XPath("//form[@action = '/Login']/*[starts-with(name(), 'h') and contains(., 'Log in')]"));
     }
+
+    public static async Task BaseThemeDependencyShouldBeEnabled(this UITestContext context)
+    {
+        await context.GoToAdminRelativeUrlAsync("/Features");
+        await context.ClickAndFillInWithRetriesAsync(By.Id("search-box"), "Helpful Widgets");
+        context.Exists(By.Id("btn-disable-Lombiq_HelpfulExtensions_Widgets"));
+    }
 }

--- a/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -62,6 +62,7 @@ public static class TestCaseUITestContextExtensions
         // through a recipe. The setup recipe in OSOCE executes the Blog recipe which already creates a menu with the
         // "main-menu" alias. As it uses a random UUID for Content Item ID, it can't be updated from another recipe (if
         // attempted the setup will throw "ValidationException: Your alias is already in use." exception).
+        // See https://github.com/Lombiq/Helpful-Libraries/issues/199 for a possible solution.
         await context.GoToAdminRelativeUrlAsync("/Contents/ContentItems/Menu");
         await context.ClickReliablyOnAsync(By.ClassName("edit"));
 

--- a/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -44,10 +44,42 @@ public static class TestCaseUITestContextExtensions
         context.Exists(By.XPath("//form[@action = '/Login']/*[starts-with(name(), 'h') and contains(., 'Log in')]"));
     }
 
-    public static async Task BaseThemeDependencyShouldBeEnabledAsync(this UITestContext context)
+    public static async Task TestBaseThemeDependencyIsEnabledAsync(this UITestContext context)
     {
         await context.GoToAdminRelativeUrlAsync("/Features");
-        await context.ClickAndFillInWithRetriesAsync(By.Id("search-box"), "Helpful Widgets");
         context.Exists(By.Id("btn-disable-Lombiq_HelpfulExtensions_Widgets"));
+    }
+
+    public static void TestBlogRecipeMenuItemsAddedToMainMenu(this UITestContext context)
+    {
+        context.Get(By.CssSelector(".menuWidget__content .nav-link[href='/']")).Text.Trim().ShouldBe("Home");
+        context.Get(By.CssSelector(".menuWidget__content .nav-link[href='/about']")).Text.Trim().ShouldBe("About");
+    }
+
+    public static async Task TestAddingMenuItemToBlogMainMenu(this UITestContext context)
+    {
+        await context.GoToAdminRelativeUrlAsync("/Contents/ContentItems/Menu");
+        await context.ClickReliablyOnAsync(By.ClassName("edit"));
+
+        await context.ClickReliablyOnAsync(By.XPath("//button[contains(., 'Add Menu Item')]"));
+        await context.ClickReliablyOnAsync(By.XPath(
+            "//div[contains(@class, 'card') and .//h4[contains(., 'Content Menu Item')]]//div[contains(@class, 'card-footer')]//a"));
+        await context.ClickAndFillInWithRetriesAsync(By.Id("ContentMenuItemPart_Name"), "My Content");
+
+        await context.SetContentPickerByDisplayTextAsync(
+            "ContentMenuItemPart",
+            "SelectedContentItem",
+            "Man must explore, and this is exploration at its greatest");
+
+        await context.ClickPublishAsync();
+        await context.ClickPublishAsync();
+        context.ShouldBeSuccess();
+
+        await context.GoToHomePageAsync();
+        context
+            .Get(By.XPath("id('navigation')//li[contains(@class, 'menuWidget__topLevel')]/a[@href='/blog/post-1']"))
+            .Text
+            .Trim()
+            .ShouldBe("My Content");
     }
 }

--- a/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -58,9 +58,10 @@ public static class TestCaseUITestContextExtensions
 
     public static async Task TestAddingMenuItemToBlogMainMenuAsync(this UITestContext context)
     {
-        // The menu item has to be added through the admin by editing the menu like this because it can't be added through a recipe. The setup recipe
-        // in OSOCE executes the Blog recipe which already creates a menu with the "main-menu" alias. As it uses a random UUID for Content Item ID, it
-        // can't be updated from another recipe (if attempted the setup will throw "ValidationException: Your alias is already in use." exception).
+        // The menu item has to be added through the admin by editing the menu like this because it can't be added
+        // through a recipe. The setup recipe in OSOCE executes the Blog recipe which already creates a menu with the
+        // "main-menu" alias. As it uses a random UUID for Content Item ID, it can't be updated from another recipe (if
+        // attempted the setup will throw "ValidationException: Your alias is already in use." exception).
         await context.GoToAdminRelativeUrlAsync("/Contents/ContentItems/Menu");
         await context.ClickReliablyOnAsync(By.ClassName("edit"));
 

--- a/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -58,6 +58,9 @@ public static class TestCaseUITestContextExtensions
 
     public static async Task TestAddingMenuItemToBlogMainMenuAsync(this UITestContext context)
     {
+        // The menu item has to be added through the admin by editing the menu like this because it can't be added through a recipe. The setup recipe
+        // in OSOCE executes the Blog recipe which already creates a menu with the "main-menu" alias. As it uses a random UUID for Content Item ID, it
+        // can't be updated from another recipe (if attempted the setup will throw "ValidationException: Your alias is already in use." exception).
         await context.GoToAdminRelativeUrlAsync("/Contents/ContentItems/Menu");
         await context.ClickReliablyOnAsync(By.ClassName("edit"));
 

--- a/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -44,7 +44,7 @@ public static class TestCaseUITestContextExtensions
         context.Exists(By.XPath("//form[@action = '/Login']/*[starts-with(name(), 'h') and contains(., 'Log in')]"));
     }
 
-    public static async Task BaseThemeDependencyShouldBeEnabled(this UITestContext context)
+    public static async Task BaseThemeDependencyShouldBeEnabledAsync(this UITestContext context)
     {
         await context.GoToAdminRelativeUrlAsync("/Features");
         await context.ClickAndFillInWithRetriesAsync(By.Id("search-box"), "Helpful Widgets");

--- a/Lombiq.BaseTheme/Services/MainMenuNavigationProvider.cs
+++ b/Lombiq.BaseTheme/Services/MainMenuNavigationProvider.cs
@@ -77,7 +77,7 @@ public class MainMenuNavigationProvider : MainMenuNavigationProviderBase
             var textContent = string.Concat(nodeList.Select(x => x.Text()));
             var url = string.IsNullOrEmpty(htmlMenuItemPart.Url) ? "#" : GetUrl(htmlMenuItemPart.Url);
 
-            builder.Add(new LocalizedString(textContent, textContent), menu => menu.Url(url).LocalNav());
+            builder.Add(T[textContent], menu => menu.Url(url).LocalNav());
         }
         else if (menuItem.As<MenuItemsListPart>() is { } menuItemsListPart)
         {

--- a/Lombiq.BaseTheme/Services/MainMenuNavigationProvider.cs
+++ b/Lombiq.BaseTheme/Services/MainMenuNavigationProvider.cs
@@ -58,7 +58,9 @@ public class MainMenuNavigationProvider : MainMenuNavigationProviderBase
 
         if (menuItem.As<LinkMenuItemPart>() is { } linkMenuItemPart)
         {
-            builder.Add(text, menu => menu.Url(linkMenuItemPart.Url));
+            var urlHelper = _urlHelperFactory.GetUrlHelper(_actionContextAccessor.ActionContext!);
+            var absoluteUri = urlHelper.Content(linkMenuItemPart.Url);
+            builder.Add(text, menu => menu.Url(absoluteUri));
         }
         else if (menuItem.As<ContentMenuItemPart>() is { } contentMenuItemPart)
         {


### PR DESCRIPTION
[OSOE-647](https://lombiq.atlassian.net/browse/OSOE-647)
Fixes #73

[OSOE-647]: https://lombiq.atlassian.net/browse/OSOE-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ