### PR TITLE
OSOE-709: MainMenuNavigationProvider.GetTitle() can throw NRE

### DIFF
--- a/Lombiq.BaseTheme/Services/MainMenuNavigationProvider.cs
+++ b/Lombiq.BaseTheme/Services/MainMenuNavigationProvider.cs
@@ -105,6 +105,9 @@ public class MainMenuNavigationProvider : MainMenuNavigationProviderBase
         }
     }
 
-    private static LocalizedString GetTitle(ContentItem contentItem) =>
-        new(contentItem.DisplayText, contentItem.DisplayText);
+    private static LocalizedString GetTitle(ContentItem contentItem)
+    {
+        var displayText = contentItem.DisplayText ?? string.Empty;
+        return new LocalizedString(displayText, displayText);
+    }
 }


### PR DESCRIPTION
[OSOE-709](https://lombiq.atlassian.net/browse/OSOE-709)
Fixes #95

[OSOE-709]: https://lombiq.atlassian.net/browse/OSOE-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ