### PR TITLE
OSOE-838:  Zone Descriptors can now have an aria-lable and other attributes, fixing Layout accessibility

### DIFF
--- a/Lombiq.BaseTheme.Samples/Lombiq.BaseTheme.Samples.csproj
+++ b/Lombiq.BaseTheme.Samples/Lombiq.BaseTheme.Samples.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' == 'true'">
-    <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.3.3-alpha.0.osoe-751" />
+    <PackageReference Include="Lombiq.NodeJs.Extensions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.BaseTheme.Tests.UI/Lombiq.BaseTheme.Tests.UI.csproj
+++ b/Lombiq.BaseTheme.Tests.UI/Lombiq.BaseTheme.Tests.UI.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' == 'true'">
-    <PackageReference Include="Lombiq.Tests.UI" Version="9.0.0" />
+    <PackageReference Include="Lombiq.Tests.UI" Version="9.1.2-alpha.0.osoe-838" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.BaseTheme.Tests.UI/Lombiq.BaseTheme.Tests.UI.csproj
+++ b/Lombiq.BaseTheme.Tests.UI/Lombiq.BaseTheme.Tests.UI.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' == 'true'">
-    <PackageReference Include="Lombiq.Tests.UI" Version="9.1.2-alpha.0.osoe-838" />
+    <PackageReference Include="Lombiq.Tests.UI" Version="9.1.2-alpha.3.osoe-838" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.BaseTheme/Lombiq.BaseTheme.csproj
+++ b/Lombiq.BaseTheme/Lombiq.BaseTheme.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' == 'true'">
-    <PackageReference Include="Lombiq.HelpfulLibraries" Version="9.0.0" />
+    <PackageReference Include="Lombiq.HelpfulLibraries" Version="9.1.1-alpha.8.osoe-838" />
     <PackageReference Include="Lombiq.HelpfulExtensions" Version="8.0.0" />
     <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.3.3-alpha.0.osoe-751" />
 

--- a/Lombiq.BaseTheme/Lombiq.BaseTheme.csproj
+++ b/Lombiq.BaseTheme/Lombiq.BaseTheme.csproj
@@ -65,7 +65,7 @@
   <ItemGroup Condition="'$(NuGetBuild)' == 'true'">
     <PackageReference Include="Lombiq.HelpfulLibraries" Version="9.1.1-alpha.8.osoe-838" />
     <PackageReference Include="Lombiq.HelpfulExtensions" Version="8.0.0" />
-    <PackageReference Include="Lombiq.NodeJs.Extensions" Version="1.3.3-alpha.0.osoe-751" />
+    <PackageReference Include="Lombiq.NodeJs.Extensions" Version="2.1.0" />
 
     <Content Include="Assets/Styles/**/*.*">
       <IncludeInPackage>true</IncludeInPackage>

--- a/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
+++ b/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
@@ -3,6 +3,7 @@ using Lombiq.BaseTheme.Constants;
 using Lombiq.BaseTheme.Services;
 using Lombiq.HelpfulLibraries.Common.Utilities;
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Localization;
 using OrchardCore.DisplayManagement.Razor;
 using OrchardCore.DisplayManagement.Zones;
 using System.Collections.Generic;
@@ -23,7 +24,7 @@ public class ZoneDescriptor
     public string ZoneName { get; set; }
     public string ElementName { get; set; }
     public bool WrapBody { get; set; }
-    public string AriaLabel { get; set; }
+    public LocalizedHtmlString AriaLabel { get; set; }
     public IDictionary<string, string> Attributes { get; private set; }
 
     public IEnumerable<ZoneDescriptor> ChildrenBefore { get; set; }
@@ -33,7 +34,7 @@ public class ZoneDescriptor
         string zoneName,
         string elementName = null,
         bool wrapBody = false,
-        string ariaLabel = null,
+        LocalizedHtmlString ariaLabel = null,
         IReadOnlyDictionary<string, string> attributes = null)
     {
         ZoneName = zoneName;
@@ -121,11 +122,10 @@ public class ZoneDescriptor
     private string GetAriaLabelAttribute(string elementName)
     {
         // Intentionally no CamelCase word-splitting the ZoneName by default, since that would involve regex for every
-        // single page view, for values that one only ever sets once.
-        if (!string.IsNullOrEmpty(AriaLabel) || _landmarkElements.Contains(elementName))
+        // single page view, for values that one only ever set once.
+        if (AriaLabel != null || _landmarkElements.Contains(elementName))
         {
-            var ariaLabel = string.IsNullOrEmpty(AriaLabel) ? ZoneName : AriaLabel;
-            return $"aria-label=\"{ariaLabel}\" ";
+            return $"aria-label=\"{AriaLabel ?? new LocalizedHtmlString(ZoneName, ZoneName)}\" ";
         }
 
         return string.Empty;

--- a/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
+++ b/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
@@ -8,6 +8,7 @@ using OrchardCore.DisplayManagement.Zones;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using static AngleSharp.Dom.TagNames;
 
 namespace Lombiq.BaseTheme.Models;
 
@@ -17,7 +18,7 @@ public class ZoneDescriptor
     public const string LeafClassName = LayoutElementClassName + "_leaf";
 
     // Elements that may be zones and are landmarks, see https://html-validate.org/rules/unique-landmark.html.
-    private static readonly string[] _landmarkElements = ["aside", "footer", "form", "header", "main", "nav", "section"];
+    private static readonly string[] _landmarkElements = [Aside, Footer, Form, Header, Main, Nav, Section];
 
     public string ZoneName { get; set; }
     public string ElementName { get; set; }
@@ -53,7 +54,7 @@ public class ZoneDescriptor
             return new HtmlString(string.Empty);
         }
 
-        ElementName ??= "div";
+        ElementName ??= Div;
 
         // The zone name should already be PascalCase.
         var id = ZoneName.ToCamelCase();
@@ -81,13 +82,13 @@ public class ZoneDescriptor
 
             var bodyAttributes = $"class=\"{bodyWrapperClass} {LeafClassName}\" " + attributesFlattened;
 
-            var elementName = "div";
+            var elementName = Div;
 
             if (ZoneName == ZoneNames.Content)
             {
                 // This improves accessibility by providing a main landmark, see:
                 // https://dequeuniversity.com/rules/axe/4.2/bypass?application=axeAPI
-                elementName = "main";
+                elementName = Main;
 
                 bodyAttributes += GetAriaLabelAttribute(elementName);
             }

--- a/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
+++ b/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
@@ -125,7 +125,7 @@ public class ZoneDescriptor
         // single page view, for values that one only ever set once.
         if (AriaLabel != null || _landmarkElements.Contains(elementName))
         {
-            return $"aria-label=\"{AriaLabel ?? new LocalizedHtmlString(ZoneName, ZoneName)}\" ";
+            return $"aria-label=\"{(AriaLabel ?? new LocalizedHtmlString(ZoneName, ZoneName)).Value}\" ";
         }
 
         return string.Empty;

--- a/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
+++ b/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
@@ -69,7 +69,7 @@ public class ZoneDescriptor
 
         var body = await page.DisplayAsync(zone);
 
-        var attributesFlattened = Attributes.Select(kvp => $"{kvp.Key}=\"{kvp.Value}\"").Join();
+        var attributesFlattened = Attributes.Select(attribute => $"{attribute.Key}=\"{attribute.Value}\"").Join();
 
         if (WrapBody)
         {

--- a/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
+++ b/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
@@ -13,11 +13,11 @@ namespace Lombiq.BaseTheme.Models;
 
 public class ZoneDescriptor
 {
-    // Elements that may be zones and are landmarks, see https://html-validate.org/rules/unique-landmark.html.
-    private static string[] _landmarkElements = ["aside", "footer", "form", "header", "main", "nav", "section"];
-
     public const string LayoutElementClassName = "layoutElement";
     public const string LeafClassName = LayoutElementClassName + "_leaf";
+
+    // Elements that may be zones and are landmarks, see https://html-validate.org/rules/unique-landmark.html.
+    private static readonly string[] _landmarkElements = ["aside", "footer", "form", "header", "main", "nav", "section"];
 
     public string ZoneName { get; set; }
     public string ElementName { get; set; }

--- a/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
+++ b/Lombiq.BaseTheme/Models/ZoneDescriptor.cs
@@ -13,21 +13,33 @@ namespace Lombiq.BaseTheme.Models;
 
 public class ZoneDescriptor
 {
+    // Elements that may be zones and are landmarks, see https://html-validate.org/rules/unique-landmark.html.
+    private static string[] _landmarkElements = ["aside", "footer", "form", "header", "main", "nav", "section"];
+
     public const string LayoutElementClassName = "layoutElement";
     public const string LeafClassName = LayoutElementClassName + "_leaf";
 
     public string ZoneName { get; set; }
     public string ElementName { get; set; }
     public bool WrapBody { get; set; }
+    public string AriaLabel { get; set; }
+    public IDictionary<string, string> Attributes { get; private set; }
 
     public IEnumerable<ZoneDescriptor> ChildrenBefore { get; set; }
     public IEnumerable<ZoneDescriptor> ChildrenAfter { get; set; }
 
-    public ZoneDescriptor(string zoneName = null, string elementName = null, bool wrapBody = false)
+    public ZoneDescriptor(
+        string zoneName,
+        string elementName = null,
+        bool wrapBody = false,
+        string ariaLabel = null,
+        IReadOnlyDictionary<string, string> attributes = null)
     {
         ZoneName = zoneName;
         ElementName = elementName;
         WrapBody = wrapBody;
+        AriaLabel = ariaLabel;
+        Attributes = attributes?.ToDictionary() ?? [];
     }
 
     public async Task<IHtmlContent> DisplayZoneAsync<TModel>(
@@ -56,6 +68,9 @@ public class ZoneDescriptor
             ChildrenBefore?.Any() != true || ChildrenAfter?.Any() != true ? LeafClassName : null);
 
         var body = await page.DisplayAsync(zone);
+
+        var attributesFlattened = Attributes.Select(kvp => $"{kvp.Key}=\"{kvp.Value}\"").Join();
+
         if (WrapBody)
         {
             // If there is no parent then "body" becomes the BEM element, otherwise there already is an element so
@@ -64,18 +79,29 @@ public class ZoneDescriptor
                 ? layoutClassName + "__body"
                 : layoutClassName + "Body";
 
-            // This improves accessibility by providing a main landmark, see:
-            // https://dequeuniversity.com/rules/axe/4.2/bypass?application=axeAPI
-            var elementName = ZoneName == ZoneNames.Content ? "main" : "div";
+            var bodyAttributes = $"class=\"{bodyWrapperClass} {LeafClassName}\" " + attributesFlattened;
+
+            var elementName = "div";
+
+            if (ZoneName == ZoneNames.Content)
+            {
+                // This improves accessibility by providing a main landmark, see:
+                // https://dequeuniversity.com/rules/axe/4.2/bypass?application=axeAPI
+                elementName = "main";
+
+                bodyAttributes += GetAriaLabelAttribute(elementName);
+            }
 
             body = new HtmlContentBuilder()
-                .AppendHtml(StringHelper.CreateInvariant($"<{elementName} class=\"{bodyWrapperClass} {LeafClassName}\">"))
+                .AppendHtml(StringHelper.CreateInvariant($"<{elementName} {bodyAttributes}>"))
                 .AppendHtml(body)
                 .AppendHtml(StringHelper.CreateInvariant($"</{elementName}>"));
         }
 
+        attributesFlattened += GetAriaLabelAttribute(ElementName);
+
         return new HtmlContentBuilder()
-            .AppendHtml(StringHelper.CreateInvariant($"<{ElementName} id=\"{id}\" class=\"{classNames}\">"))
+            .AppendHtml(StringHelper.CreateInvariant($"<{ElementName} id=\"{id}\" class=\"{classNames}\" {attributesFlattened}>"))
             .AppendHtml(await ConcatenateAsync(classHolder, page, ChildrenBefore, parent))
             .AppendHtml(body)
             .AppendHtml(await ConcatenateAsync(classHolder, page, ChildrenAfter, parent))
@@ -90,6 +116,19 @@ public class ZoneDescriptor
         zoneDescriptors == null
             ? Task.FromResult<IHtmlContent>(new HtmlString(string.Empty))
             : ConcatenateInnerAsync(classHolder, page, zoneDescriptors, ZoneName, parent);
+
+    private string GetAriaLabelAttribute(string elementName)
+    {
+        // Intentionally no CamelCase word-splitting the ZoneName by default, since that would involve regex for every
+        // single page view, for values that one only ever sets once.
+        if (!string.IsNullOrEmpty(AriaLabel) || _landmarkElements.Contains(elementName))
+        {
+            var ariaLabel = string.IsNullOrEmpty(AriaLabel) ? ZoneName : AriaLabel;
+            return $"aria-label=\"{ariaLabel}\" ";
+        }
+
+        return string.Empty;
+    }
 
     private static async Task<IHtmlContent> ConcatenateInnerAsync<TModel>(
         ICssClassHolder classHolder,

--- a/Lombiq.BaseTheme/Views/Layout.cshtml
+++ b/Lombiq.BaseTheme/Views/Layout.cshtml
@@ -22,32 +22,32 @@
     page: this,
     new[]
     {
-        new ZoneDescriptor(Header, wrapBody: true, elementName: "header", ariaLabel: "Site")
+        new ZoneDescriptor(Header, wrapBody: true, elementName: "header", ariaLabel: T["Site"])
         {
             ChildrenBefore = new [] { new ZoneDescriptor("Banner", elementName: "section") },
             ChildrenAfter = new []
             {
-                new ZoneDescriptor(Navigation, elementName: "nav", ariaLabel: "Main"),
+                new ZoneDescriptor(Navigation, elementName: "nav", ariaLabel: T["Main"]),
             },
         },
-        new ZoneDescriptor(BeforeMain, elementName: "section", ariaLabel: "Before Main"),
+        new ZoneDescriptor(BeforeMain, elementName: "section", ariaLabel: T["Before Main"]),
         new ZoneDescriptor(Featured, elementName: "section"),
         new ZoneDescriptor(Content, wrapBody: true, elementName: "section")
         {
             ChildrenBefore = new []
             {
-                new ZoneDescriptor(AsideFirst, elementName: "aside", ariaLabel: "Aside First"),
+                new ZoneDescriptor(AsideFirst, elementName: "aside", ariaLabel: T["Aside First"]),
                 new ZoneDescriptor(Messages, elementName: "section"),
-                new ZoneDescriptor(BeforeContent, elementName: "section", ariaLabel: "Before Content"),
+                new ZoneDescriptor(BeforeContent, elementName: "section", ariaLabel: T["Before Content"]),
             },
             ChildrenAfter = new []
             {
-                new ZoneDescriptor(AfterContent, elementName: "section", ariaLabel: "After Content"),
-                new ZoneDescriptor(AsideSecond, elementName: "aside", ariaLabel: "Aside Second"),
+                new ZoneDescriptor(AfterContent, elementName: "section", ariaLabel: T["After Content"]),
+                new ZoneDescriptor(AsideSecond, elementName: "aside", ariaLabel: T["Aside Second"]),
             },
         },
-        new ZoneDescriptor(AfterMain, elementName: "section", ariaLabel: "After Main"),
-        new ZoneDescriptor(Footer, elementName: "footer", ariaLabel: "Site"),
+        new ZoneDescriptor(AfterMain, elementName: "section", ariaLabel: T["After Main"]),
+        new ZoneDescriptor(Footer, elementName: "footer", ariaLabel: T["Site"]),
     })
 
 <script>

--- a/Lombiq.BaseTheme/Views/Layout.cshtml
+++ b/Lombiq.BaseTheme/Views/Layout.cshtml
@@ -1,3 +1,5 @@
+@using TagNames = AngleSharp.Dom.TagNames;
+
 <!DOCTYPE html>
 
 @inject ICssClassHolder CssClassHolder
@@ -22,32 +24,32 @@
     page: this,
     new[]
     {
-        new ZoneDescriptor(Header, wrapBody: true, elementName: "header", ariaLabel: T["Site"])
+        new ZoneDescriptor(Header, wrapBody: true, elementName: TagNames.Header, ariaLabel: T["Site"])
         {
-            ChildrenBefore = new [] { new ZoneDescriptor("Banner", elementName: "section") },
+            ChildrenBefore = new [] { new ZoneDescriptor("Banner", elementName: TagNames.Section) },
             ChildrenAfter = new []
             {
-                new ZoneDescriptor(Navigation, elementName: "nav", ariaLabel: T["Main"]),
+                new ZoneDescriptor(Navigation, elementName: TagNames.Nav, ariaLabel: T["Main"]),
             },
         },
-        new ZoneDescriptor(BeforeMain, elementName: "section", ariaLabel: T["Before Main"]),
-        new ZoneDescriptor(Featured, elementName: "section"),
-        new ZoneDescriptor(Content, wrapBody: true, elementName: "section")
+        new ZoneDescriptor(BeforeMain, elementName: TagNames.Section, ariaLabel: T["Before Main"]),
+        new ZoneDescriptor(Featured, elementName: TagNames.Section),
+        new ZoneDescriptor(Content, wrapBody: true, elementName: TagNames.Section)
         {
             ChildrenBefore = new []
             {
-                new ZoneDescriptor(AsideFirst, elementName: "aside", ariaLabel: T["Aside First"]),
-                new ZoneDescriptor(Messages, elementName: "section"),
-                new ZoneDescriptor(BeforeContent, elementName: "section", ariaLabel: T["Before Content"]),
+                new ZoneDescriptor(AsideFirst, elementName: TagNames.Aside, ariaLabel: T["Aside First"]),
+                new ZoneDescriptor(Messages, elementName: TagNames.Section),
+                new ZoneDescriptor(BeforeContent, elementName: TagNames.Section, ariaLabel: T["Before Content"]),
             },
             ChildrenAfter = new []
             {
-                new ZoneDescriptor(AfterContent, elementName: "section", ariaLabel: T["After Content"]),
-                new ZoneDescriptor(AsideSecond, elementName: "aside", ariaLabel: T["Aside Second"]),
+                new ZoneDescriptor(AfterContent, elementName: TagNames.Section, ariaLabel: T["After Content"]),
+                new ZoneDescriptor(AsideSecond, elementName: TagNames.Aside, ariaLabel: T["Aside Second"]),
             },
         },
-        new ZoneDescriptor(AfterMain, elementName: "section", ariaLabel: T["After Main"]),
-        new ZoneDescriptor(Footer, elementName: "footer", ariaLabel: T["Site"]),
+        new ZoneDescriptor(AfterMain, elementName: TagNames.Section, ariaLabel: T["After Main"]),
+        new ZoneDescriptor(Footer, elementName: TagNames.Footer, ariaLabel: T["Site"]),
     })
 
 <script>

--- a/Lombiq.BaseTheme/Views/Layout.cshtml
+++ b/Lombiq.BaseTheme/Views/Layout.cshtml
@@ -22,32 +22,32 @@
     page: this,
     new[]
     {
-        new ZoneDescriptor(Header, wrapBody: true, elementName: "header")
+        new ZoneDescriptor(Header, wrapBody: true, elementName: "header", ariaLabel: "Site")
         {
             ChildrenBefore = new [] { new ZoneDescriptor("Banner", elementName: "section") },
             ChildrenAfter = new []
             {
-                new ZoneDescriptor(Navigation, elementName: "nav"),
+                new ZoneDescriptor(Navigation, elementName: "nav", ariaLabel: "Main"),
             },
         },
-        new ZoneDescriptor(BeforeMain, elementName: "section"),
+        new ZoneDescriptor(BeforeMain, elementName: "section", ariaLabel: "Before Main"),
         new ZoneDescriptor(Featured, elementName: "section"),
         new ZoneDescriptor(Content, wrapBody: true, elementName: "section")
         {
             ChildrenBefore = new []
             {
-                new ZoneDescriptor(AsideFirst, elementName: "aside"),
+                new ZoneDescriptor(AsideFirst, elementName: "aside", ariaLabel: "Aside First"),
                 new ZoneDescriptor(Messages, elementName: "section"),
-                new ZoneDescriptor(BeforeContent, elementName: "section"),
+                new ZoneDescriptor(BeforeContent, elementName: "section", ariaLabel: "Before Content"),
             },
             ChildrenAfter = new []
             {
-                new ZoneDescriptor(AfterContent, elementName: "section"),
-                new ZoneDescriptor(AsideSecond, elementName: "aside"),
+                new ZoneDescriptor(AfterContent, elementName: "section", ariaLabel: "After Content"),
+                new ZoneDescriptor(AsideSecond, elementName: "aside", ariaLabel: "Aside Second"),
             },
         },
-        new ZoneDescriptor(AfterMain, elementName: "section"),
-        new ZoneDescriptor(Footer, "footer"),
+        new ZoneDescriptor(AfterMain, elementName: "section", ariaLabel: "After Main"),
+        new ZoneDescriptor(Footer, elementName: "footer", ariaLabel: "Site"),
     })
 
 <script>


### PR DESCRIPTION
[OSOE-838](https://lombiq.atlassian.net/browse/OSOE-838)

[OSOE-838]: https://lombiq.atlassian.net/browse/OSOE-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ