### PR TITLE
OSOE-847: Removing now unnecessary true isChecked parameter from methods

### DIFF
--- a/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
+++ b/Lombiq.BaseTheme.Tests.UI/Extensions/TestCaseUITestContextExtensions.cs
@@ -95,7 +95,7 @@ public static class TestCaseUITestContextExtensions
         By byIcon = null)
     {
         await context.GoToAdminRelativeUrlAsync("/Lombiq.BaseTheme/Admin/Index");
-        await context.SetCheckboxValueAsync(By.Id("HideMenu"), isChecked: true);
+        await context.SetCheckboxValueAsync(By.Id("HideMenu"));
 
         await context.ClickReliablyOnAsync(By.XPath("//div[contains(@class, 'thumb-container')]"));
         await context.ClickReliablyOnAsync(By.CssSelector("#Editor .delete-button").OfAnyVisibility());


### PR DESCRIPTION
[OSOE-847](https://lombiq.atlassian.net/browse/OSOE-847)

[OSOE-847]: https://lombiq.atlassian.net/browse/OSOE-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ