### PR TITLE
OSOE-898: MainMenuNavigationProvider doesn't add LocalNav to LinkMenuItems so everything will open in a new tab in Lombiq.BaseTheme

### DIFF
--- a/Lombiq.BaseTheme/Services/MainMenuNavigationProvider.cs
+++ b/Lombiq.BaseTheme/Services/MainMenuNavigationProvider.cs
@@ -58,7 +58,7 @@ public class MainMenuNavigationProvider : MainMenuNavigationProviderBase
 
         if (menuItem.As<LinkMenuItemPart>() is { } linkMenuItemPart)
         {
-            builder.Add(text, menu => menu.Url(linkMenuItemPart.Url));
+            builder.Add(text, menu => menu.Url(linkMenuItemPart.Url).LocalNav());
         }
         else if (menuItem.As<ContentMenuItemPart>() is { } contentMenuItemPart)
         {


### PR DESCRIPTION
[OSOE-898](https://lombiq.atlassian.net/browse/OSOE-898)
Fixes #121

[OSOE-898]: https://lombiq.atlassian.net/browse/OSOE-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ