### PR TITLE
ADHOC-424: Preventing NRE when no site theme is configured

### DIFF
--- a/Lombiq.BaseTheme.Core/Services/IconResourceFilter.cs
+++ b/Lombiq.BaseTheme.Core/Services/IconResourceFilter.cs
@@ -38,7 +38,7 @@ public class IconResourceFilter : IResourceFilterProvider
             {
                 // Use static link resources as a fallback.
                 var currentTheme = await _siteThemeService.GetSiteThemeAsync();
-                if (currentTheme.Manifest.ModuleInfo is DerivedThemeAttribute theme)
+                if (currentTheme?.Manifest.ModuleInfo is DerivedThemeAttribute theme)
                 {
                     if (!string.IsNullOrEmpty(theme.Favicon))
                     {


### PR DESCRIPTION
[ADHOC-424](https://lombiq.atlassian.net/browse/ADHOC-424)

[ADHOC-424]: https://lombiq.atlassian.net/browse/ADHOC-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ