### PR TITLE
OSOE-1254: Fix MA0127 analyzer warning in BreakpointBodyClassProvider

### DIFF
--- a/Lombiq.BaseTheme.Native/Services/BreakpointBodyClassProvider.cs
+++ b/Lombiq.BaseTheme.Native/Services/BreakpointBodyClassProvider.cs
@@ -41,7 +41,9 @@ public class BreakpointBodyClassProvider : SyncBodyClassProvider
         var results = new List<string>
         {
             $"{Prefix}{size}",
-            size is "xs" or "sm" ? $"{Prefix}small" : $"{Prefix}big",
+            size.EqualsOrdinalIgnoreCase("xs") || size.EqualsOrdinalIgnoreCase("sm")
+                ? $"{Prefix}small"
+                : $"{Prefix}big",
         };
 
         var sizes = _sizes.Keys.ToList();


### PR DESCRIPTION
[OSOE-1254](https://lombiq.atlassian.net/browse/OSOE-1254): Fix MA0127 analyzer warning.

- Use EqualsOrdinalIgnoreCase instead of is pattern in BreakpointBodyClassProvider

[OSOE-1254]: https://lombiq.atlassian.net/browse/OSOE-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ